### PR TITLE
[ 단순 수정 ]

### DIFF
--- a/src/main/java/com/onetouch/delinight/Controller/MembersController.java
+++ b/src/main/java/com/onetouch/delinight/Controller/MembersController.java
@@ -15,13 +15,11 @@ import com.onetouch.delinight.Service.MembersService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.data.domain.Page;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 
 import java.security.Principal;
-import java.util.List;
 
 @Controller
 @RequiredArgsConstructor
@@ -45,6 +43,18 @@ public class MembersController {
     public String adminhome() {
         return "/members/adminhome";
 
+    }
+
+    @GetMapping("/adminmypage")
+    public String adminMyPage(Principal principal, Model model){
+
+        return "/members/adminmypage";
+    }
+
+    @GetMapping("/adminupdate")
+    public String adminUpdate(Principal principal, Model model){
+
+        return "/members/adminupdate";
     }
 
     @GetMapping("/create")
@@ -194,7 +204,7 @@ public class MembersController {
         return "members/storeadlist";
     }
 
-   
+
     //@PostMapping("/adminlogin")
     //public String adminlogin(@RequestParam String email,
     //                         @RequestParam String password,

--- a/src/main/java/com/onetouch/delinight/Controller/ViewController.java
+++ b/src/main/java/com/onetouch/delinight/Controller/ViewController.java
@@ -57,11 +57,7 @@ public class ViewController {
     }
 
 
-    @GetMapping("/members/update")
-    public String adminUpdate(Principal principal, Model model){
 
-        return "/members/update";
-    }
 
     @GetMapping("/register")
     public String register() {

--- a/src/main/java/com/onetouch/delinight/Service/MembersService.java
+++ b/src/main/java/com/onetouch/delinight/Service/MembersService.java
@@ -21,6 +21,7 @@ import java.util.Map;
 public interface MembersService {
 
     public void create(MembersDTO membersDTO);
+    public MembersDTO update(MembersDTO membersDTO);
 
     public void hoteladcreate(MembersDTO membersDTO);
     public void storeadcreate(MembersDTO membersDTO);
@@ -32,15 +33,12 @@ public interface MembersService {
 
     public List<MembersDTO> findAll();
 
-
-    public String login(String email, String password);
-
 //    public List<MembersDTO> findSuper();
 
     Page<MembersEntity> findHotelAd(Status status, int page);
 
 
-    public List<MembersDTO> findSuper();
+    //public List<MembersDTO> findSuper();
     public List<MembersDTO> findHotelAd();
     public List<MembersDTO> findStoreAd();
 

--- a/src/main/java/com/onetouch/delinight/Service/MembersServiceImpl.java
+++ b/src/main/java/com/onetouch/delinight/Service/MembersServiceImpl.java
@@ -27,6 +27,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Log4j2
@@ -53,6 +54,20 @@ public class MembersServiceImpl implements MembersService{
             membersRepository.save(membersEntity);
 
 
+    }
+
+    @Override
+    public MembersDTO update(MembersDTO membersDTO) {
+        Optional<MembersEntity> optionalMembersEntity
+                = membersRepository.findById(membersDTO.getId());
+
+        MembersEntity membersEntity = optionalMembersEntity.get();
+        membersEntity.setPhone(membersDTO.getPhone());
+        membersEntity.setPassword(membersDTO.getPassword());
+        if (membersDTO.getPassword() == null){
+
+        }
+        return null;
     }
 
     @Override
@@ -87,42 +102,27 @@ public class MembersServiceImpl implements MembersService{
         return membersDTOList;
     }
 
+    //@Override
+    //public List<MembersDTO> findSuper() {
+    //    List<MembersEntity> membersEntityList = membersRepository.selectSuperAd();
+    //
+    //    List<MembersDTO> membersDTOList =
+    //    membersEntityList.stream().toList().stream().map(
+    //            membersEntity -> modelMapper.map(membersEntity, MembersDTO.class)
+    //    ).collect(Collectors.toList());
+    //
+    //    return membersDTOList;
+    //}
+
     @Override
-    public String login(String email, String password) {
-        MembersEntity membersEntity = membersRepository.selectEmail(email);
-        log.info("이메일로 조회한 db 회원정보 : "+membersEntity);
-
-
-
-        if(membersEntity == null){
-            log.info("db에 회원정보 없음");
-            return "회원 정보가 없습니다.";
-        }
-
-        if(!membersEntity.getEmail().equals(password)){
-            log.info("db에 회원정보는 있으나 비번이 틀림");
-            return "비밀번호가 틀립니다.";
-        }
-        log.info("서비스 수행 완료");
-        return null;
+    public List<MembersDTO> findHotelAd() {
+        return List.of();
     }
 
-    public List<MembersDTO> findSuper() {
-        List<MembersEntity> membersEntityList = membersRepository.selectSuperAd();
-
-
-
-//    @Override
-//    public List<MembersDTO> findSuper() {
-//        List<MembersEntity> membersEntityList = membersRepository.selectSuperAd();
-//
-//        List<MembersDTO> membersDTOList =
-//        membersEntityList.stream().toList().stream().map(
-//                membersEntity -> modelMapper.map(membersEntity, MembersDTO.class)
-//        ).collect(Collectors.toList());
-//
-//        return membersDTOList;
-//    }
+    @Override
+    public List<MembersDTO> findStoreAd() {
+        return List.of();
+    }
 
     @Override
     public Page<MembersEntity> findHotelAd(Status status, int page) {
@@ -136,17 +136,17 @@ public class MembersServiceImpl implements MembersService{
     }
 
 
-
-    @Override
-    public Page<MembersEntity> findStoreAd(Status status, int page) {
-
-
-        List<Sort.Order> sorts = new ArrayList<>();
-        sorts.add(Sort.Order.desc("id"));
-        Pageable pageable = PageRequest.of(page, 10, Sort.by(sorts));
-        return this.membersRepository.selectStoreAd(pageable);
-
-    }
+    //
+    //@Override
+    //public Page<MembersEntity> findStoreAd(Status status, int page) {
+    //
+    //
+    //    List<Sort.Order> sorts = new ArrayList<>();
+    //    sorts.add(Sort.Order.desc("id"));
+    //    Pageable pageable = PageRequest.of(page, 10, Sort.by(sorts));
+    //    return this.membersRepository.selectStoreAd(pageable);
+    //
+    //}
 
     @Override
     public Page<MembersEntity> getList(int page) {

--- a/src/main/resources/static/css/styles.css
+++ b/src/main/resources/static/css/styles.css
@@ -2082,8 +2082,6 @@ progress {
   margin-bottom: 0;
   line-height: 1.5;
   color: #212529;
-  background-color: transparent;
-  border: solid transparent;
   border-width: 1px 0;
 }
 .form-control-plaintext:focus {
@@ -3682,11 +3680,15 @@ textarea.form-control-lg {
   display: inline-block;
 }
 
+.icon-wrap div {
+  font-size: 20px;
+}
+
 .notification-badge {
   position: absolute;
-  height: 15px;
-  top: 0px;
-  right: -5px;
+  height: 14px;
+  top: 4px;
+  right: -3px;
   background: #ff1500;
   color: white;
   font-size: 10px;
@@ -3694,7 +3696,6 @@ textarea.form-control-lg {
   border-radius: 999px;
   line-height: 1;
   min-width: 18px;
-  text-align: center;
 }
 
 .form-label {
@@ -3771,12 +3772,21 @@ textarea.form-control-lg {
 }
 
 .avatar {
-  width: 54px;
-  height: 54px;
   background-color: #eee;
   background-size: cover;
+}
+
+#profile-avatar {
+  width: 54px;
+  height: 54px;
   border-radius: 50%;
   flex-shrink: 0;
+
+}
+
+#mypage-avatar {
+  width: 200px;
+  height: 100%;
 }
 
 .user-info {

--- a/src/main/resources/static/js/alert.js
+++ b/src/main/resources/static/js/alert.js
@@ -43,7 +43,7 @@ $(document).ready(function () {
 
 
 
-    $(".confirmStart").click(function () {
+    $("#confirmStart").click(function () {
 
         Swal.fire({
 

--- a/src/main/resources/templates/fragments/adminheader.html
+++ b/src/main/resources/templates/fragments/adminheader.html
@@ -12,7 +12,7 @@
     <nav th:fragment="adminHeader" class="sb-topnav navbar navbar-expand navbar-dark bg-dark">
         <!-- Navbar Brand-->
         <div class="navbar-brand ps-3">
-            <a class="navbar-brand-a" href="/">Deli-Nigth</a>
+            <a class="navbar-brand-a" href="/members/account/adminhome">Deli-Nigth</a>
         </div>
         <!-- Sidebar Toggle-->
         <button class="btn btn-link btn-sm order-1 order-lg-0 me-4 me-lg-0" id="sidebarToggle" href="#!"><i class="fas fa-bars"></i></button>
@@ -20,13 +20,13 @@
         <div class="navbar-nav ms-auto me-3 me-lg-4">
             <div class="navbar-hover">
                 <div class="icon-wrap">
-                    <div class="nav-link"><i class="fas fa-user"></i></div>
+                    <div class="nav-link"><i class="fas fa-circle-user"></i></div>
                     <span class="notification-badge custom-shadow">7</span>
                 </div>
                 <div class="profile-tooltip-wrap">
                     <div class="profile-tooltip custom-shadow">
                         <div class="profile-header">
-                            <img class="avatar" src="/img/defaultImg.png" alt="#">
+                            <img class="avatar" id="profile-avatar" src="/img/defaultImg.png" alt="#">
                             <div class="user-info">
                                 <div class="user-info-title">
                                     <strong th:text="${membersDTO.name}"></strong>
@@ -37,7 +37,7 @@
                             </div>
                         </div>
                         <ul class="menu-list">
-                            <li><a href="/members/update"><i class="fas fa-pen"></i>정보수정</a></li>
+                            <li><a href="/members/account/adminmypage"><i class="fas fa-user"></i>마이페이지</a></li>
                             <div class="icon-wrap">
                                 <li><a><i class="fas fa-bell"></i>알림함</a></li>
                                 <span class="notification-badge custom-shadow">7</span>

--- a/src/main/resources/templates/members/adminhome.html
+++ b/src/main/resources/templates/members/adminhome.html
@@ -17,30 +17,40 @@
 <div layout:fragment="adminContent" id="layoutSidenav_content">
     <main>
         <div class="container-fluid px-5">
-            <!--내용 넣는 곳-->
-            <!--반드시 이 아래에서만 작업-->
+            <!--작업 영역-->
+            <!--반드시 이 안에서만 작업-->
 
-            <!--페이지 이름-->
+            <!--페이지 제목 명명-->
             <h3 class="mt-5">어드민 홈</h3>
             <ol class="breadcrumb mb-4">
-                <li class="breadcrumb-item active">큰페이지 〉 중간페이지 〉 작은페이지</li>
+                <!--페이지 소제목 명명-->
+                <li class="breadcrumb-item active" th:text="'환영합니다, '+${membersDTO.name}+' 님'"></li>
             </ol>
 
-            <!--텍스트 박스-->
+            <!--기본 카드 양식-->
             <div class="card custom-shadow mb-4">
                 <div class="card-body">
+                    <!--카드 제목-->
                     <h5 class="mb-4 fw-bold">기본 정보</h5>
 
+                    <!--카드 제목 구분선-->
                     <hr class="hrMain">
 
+                    <!--기본 row 양식-->
+                    <!--양식처럼 요소를 깔끔하게 배치하고 싶다면 이 div를 그대로 복붙한 뒤 내용을 수정하세요-->
+                    <!--이때, row는 행이므로 이 클래스를 삭제하면 요소에 col이 먹지 않습니다-->
+                    <!--이때, col-sm-숫자 는 row에서 요소가 차지하는 자리비율이므로 col이 여러개일 시 +-가 필요합니다(하나를 높이면 하나를 줄여야함)-->
                     <div class="row mb-1">
+                        <!--row 제목 (기본 col-sm-2)-->
                         <label class="col-sm-2 col-form-label form-label">리드온리 인풋창</label>
+                        <!--row 콘텐츠 (기본 col-sm-4-->
                         <div class="col-sm-4">
                             <input type="text" readonly class="form-control-plaintext" id="staticMembersName" value="홍길동">
                         </div>
                     </div>
 
-                    <hr><!--구분선-->
+                    <!--기본 구분선-->
+                    <hr>
 
                     <div class="row mb-4">
                         <label class="col-sm-2 col-form-label form-label">일반 인풋창</label>
@@ -50,7 +60,7 @@
                     </div>
 
                     <div class="row mb-4">
-                        <label class="col-sm-2 col-form-label form-label">전화번호</label>
+                        <label class="col-sm-2 col-form-label form-label">플레이스홀더&작은글</label>
                         <div class="col-sm-10">
                             <input type="number" class="form-control" id="staticMembersPhone" maxlength="13" placeholder="원래있던번호">
                             <div class="text-sm mt-1">
@@ -66,6 +76,9 @@
                                 <input type="file" class="form-control w-50 me-2">
                                 <button class="btn btn-gray">파일 선택</button>
                             </div>
+                            <div class="text-sm mt-1">
+                                accept=""으로 첨부 가능한 파일 형식 지정 가능
+                            </div>
                         </div>
                     </div>
 
@@ -76,39 +89,22 @@
                 </div>
             </div>
 
-            <!--알럿창-->
+            <!--기본 알럿 양식-->
+            <!--알럿 사용 시, alert.js 파일에서 사용할 부분만 복사한 뒤 본 작업파일 하단 스크립트란에 붙여 사용-->
             <div class="card custom-shadow mb-4">
-                <div class="card-header">
-                    <!--아이콘-->
-                    <!--카드헤더 제목 넣는곳-->
-                    <i class="fas fa-table me-1"></i>
-
-                    알럿창
-                </div>
                 <div class="card-body">
-                    <!--카드바디 내용 넣는곳-->
+                    <h5 class="mb-4 fw-bold">알럿창</h5>
+                    <hr class="hrMain">
+
+                    <!--알럿 버튼 양식-->
+                    <!--마음에 드는 양식을 골라 복붙하여 사용(클래스 따라 css가 자동으로 적용됨)-->
+                    <!--이때, 자신이 사용할 이름으로 반드시 id 바꿔줄것(하단 스크립트 포함)-->
+                    <!--id를 바꾸지 않으면 새 스크립트를 쓰든말든 기존의 양식과 똑같이 실행돼버림-->
                     <button class="btn btn-primary m-2" id="alertStart">Alert 실행</button>
                     <button class="btn btn-gray m-2" id="confirmStart">Confirm 실행</button>
                     <button class="btn btn-success m-2" id="promptStart">Prompt 실행</button>
                     <button class="btn btn-danger m-2" id="toastStart">Toast 실행</button>
                     <button class="btn btn-warning m-2" id="ajaxStart">Ajax 실행 (깃헙 아이디 검색)</button>
-                </div>
-            </div>
-
-            <!--카드-->
-            <div class="card custom-shadow mb-4">
-                <div class="card-header">
-                    <!--아이콘-->
-                    <!--카드헤더 제목 넣는곳-->
-                    <i class="fas fa-table me-1"></i>
-
-                    card title
-                </div>
-                <div class="card-body">
-                    <!--카드바디 내용 넣는곳-->
-                    <div>
-                        내용내용내용내용내용내용내용
-                    </div>
                 </div>
             </div>
         </div>

--- a/src/main/resources/templates/members/adminmypage.html
+++ b/src/main/resources/templates/members/adminmypage.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="ko"
+      xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layouts/layout}"
+>
+    <head>
+        <title>델리나잇</title>
+
+        <!--별도 css 필요할 시 아래로 추가-->
+        <!--어디서 그대로 가져오는거 아니면 클래스 이름 잘 붙여주고
+        styles.css에 작성할것-->
+    </head>
+
+    <body>
+        <!--이 줄 div layout:fragment명과 id명 절대 수정 금지!!!!-->
+        <div layout:fragment="adminContent" id="layoutSidenav_content">
+            <main>
+                <div class="container-fluid px-5">
+                    <!--내용 넣는 곳-->
+                    <!--반드시 이 아래에서만 작업-->
+
+                    <!--페이지 이름-->
+                    <h3 class="mt-5">마이페이지</h3>
+                    <ol class="breadcrumb mb-4">
+                        <li class="breadcrumb-item active">홈 〉 마이페이지</li>
+                    </ol>
+
+                    <!--텍스트 박스-->
+                    <div class="card mb-4 custom-shadow">
+                       <div class="card-body">
+
+                           <h5 class="mb-4 fw-bold">기본 정보</h5>
+
+                           <hr class="hrMain">
+
+                           <div class="row mb-1">
+                               <label class="col-sm-2 col-form-label form-label">관리자 이름</label>
+                               <div class="col-sm-4">
+                                   <input type="text" readonly class="form-control-plaintext" th:value="${membersDTO.name}">
+                               </div>
+                           </div>
+
+                           <div class="row mb-1">
+                               <label class="col-sm-2 col-form-label form-label">관리자 등급</label>
+                               <div class="col-sm-4">
+                                   <input type="text" readonly class="form-control-plaintext" th:value="${membersDTO.role}">
+                               </div>
+                           </div>
+
+                           <div class="row mb-1">
+                               <label class="col-sm-2 col-form-label form-label">이메일</label>
+                               <div class="col-sm-6">
+                                   <input type="email" readonly class="form-control-plaintext" th:value="${membersDTO.email}">
+                               </div>
+                           </div>
+
+                           <div class="row mb-4">
+                               <label class="col-sm-2 col-form-label form-label">전화번호</label>
+                               <div class="col-sm-6">
+                                   <input type="text" class="form-control-plaintext" th:value="${membersDTO.phone}" readonly>
+                               </div>
+                           </div>
+
+                           <hr>
+
+                           <div class="row mb-4">
+                               <label class="col-sm-2 col-form-label form-label">프로필 이미지</label>
+                               <div class="col-sm-10">
+                                   <img class="avatar" id="mypage-avatar" src="/img/defaultImg.png" alt="#">
+                               </div>
+                           </div>
+
+                           <div class="text-center mt-5">
+                               <a href="/members/account/adminupdate" class="btn btn-primary me-2 px-4" id="delbtn">수정</a>
+                               <a href="/members/account/adminhome" class="btn btn-gray px-4">취소</a>
+                           </div>
+                       </div>
+                    </div>
+
+                </div>
+            </main>
+
+            <!--푸터 절대 수정 금지!!!!-->
+            <!--푸터-->
+            <div th:replace="~{fragments/adminfooter::adminFooter}"></div>
+        </div>
+
+    </body>
+</html>

--- a/src/main/resources/templates/members/adminupdate.html
+++ b/src/main/resources/templates/members/adminupdate.html
@@ -23,7 +23,7 @@
                     <!--페이지 이름-->
                     <h3 class="mt-5">정보수정</h3>
                     <ol class="breadcrumb mb-4">
-                        <li class="breadcrumb-item active">마이페이지 〉 정보수정</li>
+                        <li class="breadcrumb-item active">홈 〉 마이페이지 〉 정보수정</li>
                     </ol>
 
                     <!--텍스트 박스-->
@@ -34,90 +34,96 @@
 
                            <hr class="hrMain">
 
-                           <div class="row mb-1">
-                               <label class="col-sm-2 col-form-label form-label">관리자 이름</label>
-                               <div class="col-sm-4">
-                                   <input type="text" readonly class="form-control-plaintext" th:value="${membersDTO.name}">
-                               </div>
-                           </div>
-
-                           <div class="row mb-1">
-                               <label class="col-sm-2 col-form-label form-label">관리자 등급</label>
-                               <div class="col-sm-4">
-                                   <input type="text" readonly class="form-control-plaintext" th:value="${membersDTO.role}">
-                               </div>
-                           </div>
-
-                           <div class="row mb-1">
-                               <label class="col-sm-2 col-form-label form-label">이메일</label>
-                               <div class="col-sm-6">
-                                   <input type="email" readonly class="form-control-plaintext" th:value="${membersDTO.email}">
-                               </div>
-                           </div>
-
-                           <hr>
-
-                           <div class="row mb-4">
-                               <label class="col-sm-2 col-form-label form-label">전화번호</label>
-                               <div class="col-sm-10">
-                                   <input type="text" class="form-control" id="staticMembersPhone" maxlength="13" th:placeholder="${membersDTO.phone}">
-                                   <div class="text-sm mt-1">
-                                       변경할 전화번호를 입력해주세요.
-                                   </div>
-                               </div>
-                           </div>
-
-                           <div class="row mb-4">
-                               <label class="col-sm-2 col-form-label form-label">프로필 이미지</label>
-                               <div class="col-sm-10">
-                                   <div class="d-flex">
-                                       <input type="file" accept="image/*" class="form-control w-50 me-2">
-                                       <button class="btn btn-gray">파일 선택</button>
-                                   </div>
-                                   <div class="text-sm mt-1">
-                                       업로드 가능한 이미지 파일(jpg, jpeg, png, gif, svg, webp, ico)만 가능합니다.<br>
-                                   </div>
-                               </div>
-                           </div>
-
-                           <div class="row mb-4">
-                               <label class="col-sm-2 col-form-label form-label">로그인 비밀번호</label>
-                               <div class="col-sm-3">
-                                   <button class="btn btn-gray-outline" id="togglePasswordChange">비밀번호 변경</button>
-                               </div>
-                               <div class="col-sm-1 iconX">
-                                   <div>&times;</div>
-                               </div>
-                           </div>
-
-                           <div id="passwordChangeSection">
-                               <div class="row mb-4">
-                                   <label class="col-sm-2 col-form-label form-label">현재 비밀번호</label>
+                           <form action="/members/adminupdate" method="post" enctype="multipart/form-data">
+                               <div class="row mb-1">
+                                   <label class="col-sm-2 col-form-label form-label">관리자 이름</label>
                                    <div class="col-sm-4">
-                                       <input type="password" class="form-control" maxlength="16">
+                                       <input type="text" readonly class="form-control-plaintext" th:value="${membersDTO.name}">
                                    </div>
                                </div>
-                               <div class="row mb-4">
-                                   <label class="col-sm-2 col-form-label form-label">새 비밀번호</label>
+
+                               <div class="row mb-1">
+                                   <label class="col-sm-2 col-form-label form-label">관리자 등급</label>
                                    <div class="col-sm-4">
-                                       <input type="password" class="form-control" maxlength="16">
+                                       <input type="text" readonly class="form-control-plaintext" th:value="${membersDTO.role}">
+                                   </div>
+                               </div>
+
+                               <div class="row mb-1">
+                                   <label class="col-sm-2 col-form-label form-label">이메일</label>
+                                   <div class="col-sm-6">
+                                       <input type="email" readonly class="form-control-plaintext" th:value="${membersDTO.email}">
+                                   </div>
+                               </div>
+
+                               <hr>
+
+                               <div class="row mb-4">
+                                   <label class="col-sm-2 col-form-label form-label">전화번호</label>
+                                   <div class="col-sm-10">
+                                       <input type="text" class="form-control" id="staticMembersPhone" name="phone" maxlength="13" th:placeholder="${membersDTO.phone}">
                                        <div class="text-sm mt-1">
-                                           영문/숫자/특수문자 조합(8~16자로 작성) <br>
+                                           변경할 전화번호를 입력해주세요.
                                        </div>
                                    </div>
                                </div>
+
                                <div class="row mb-4">
-                                   <label class="col-sm-2 col-form-label form-label">새 비밀번호 확인</label>
-                                   <div class="col-sm-4">
-                                       <input type="password" class="form-control" maxlength="16">
+                                   <label class="col-sm-2 col-form-label form-label">프로필 이미지</label>
+                                   <div class="col-sm-10">
+                                       <div class="d-flex">
+                                           <input type="file" accept="image/*" name="membersImage" class="form-control w-50 me-2">
+                                           <button class="btn btn-gray">파일 선택</button>
+                                       </div>
+                                       <div class="text-sm mt-1">
+                                           업로드 가능한 이미지 파일(jpg, jpeg, png, gif, svg, webp, ico)만 가능합니다.<br>
+                                       </div>
+                                       <div class="col-sm-10">
+                                           <input type="hidden" name="membersImage" th:value="${images}"><!--엄청 중요!! 수정 시 기본키값이 존재해야함-->
+                                           <img class="avatar" name="membersImage" id="mypage-avatar" src="/img/defaultImg.png" alt="#">
+                                       </div>
                                    </div>
                                </div>
-                           </div>
 
-                           <div class="text-center mt-5">
-                               <button class="btn btn-primary me-2 px-4" id="delbtn">저장</button>
-                               <button class="btn btn-gray px-4">취소</button>
-                           </div>
+                               <div class="row mb-4">
+                                   <label class="col-sm-2 col-form-label form-label">로그인 비밀번호</label>
+                                   <div class="col-sm-3">
+                                       <button class="btn btn-gray-outline" id="togglePasswordChange">비밀번호 변경</button>
+                                   </div>
+                                   <div class="col-sm-1 iconX">
+                                       <div>&times;</div>
+                                   </div>
+                               </div>
+
+                               <div id="passwordChangeSection">
+                                   <div class="row mb-4">
+                                       <label class="col-sm-2 col-form-label form-label">현재 비밀번호</label>
+                                       <div class="col-sm-4">
+                                           <input type="password" class="form-control" maxlength="16">
+                                       </div>
+                                   </div>
+                                   <div class="row mb-4">
+                                       <label class="col-sm-2 col-form-label form-label">새 비밀번호</label>
+                                       <div class="col-sm-4">
+                                           <input type="password" class="form-control" name="password" maxlength="16">
+                                           <div class="text-sm mt-1">
+                                               영문/숫자/특수문자 조합(8~16자로 작성) <br>
+                                           </div>
+                                       </div>
+                                   </div>
+                                   <div class="row mb-4">
+                                       <label class="col-sm-2 col-form-label form-label">새 비밀번호 확인</label>
+                                       <div class="col-sm-4">
+                                           <input type="password" class="form-control" maxlength="16">
+                                       </div>
+                                   </div>
+                               </div>
+
+                               <div class="text-center mt-5">
+                                   <a class="btn btn-primary me-2 px-4" id="delbtn">저장</a>
+                                   <a href="/members/account/adminmypage" class="btn btn-gray px-4">취소</a>
+                               </div>
+                           </form>
                        </div>
                     </div>
 


### PR DESCRIPTION
1. alert.js에서 confirmStrart가 제대로 작동하도록 수정(.confirmStrart를 #confirmStrart로 바꿔줌)
2. MembersService와 MembersServiceImpl에서 불필요해진 login 관련 코드 삭제
3. adminhome.html 양식을 index와 동일해지도록 수정
4. adminheader.html에서 좌측상단 로고를 누르면 index가 아니라 adminhome으로 이동하도록 수정
5. 아이콘 변경

[ 어드민 마이페이지 ]
>>기존 마이페이지는 헤더에서 버튼 클릭 후 바로 수정 페이지로 이동되었음. 이때 보기만 가능한 마이페이지가 없기에 새로 추가해주기로 결정

1. adminmypage.html 생성
2. adminmypage.html와 update.html를 기존 뷰 컨트롤러에서 멤버컨트롤러로 옮겨줌(멤버 컨트롤러에서 쉽게 모아 보기위함)
3. adminheader.html의 기존 정보수정 버튼 수정 ㄴ정보수정 > 마이페이지 ㄴ따라서 update.html가 아니라 adminmypage.html로 이동하도록 a링크 수정
4. 이 과정에 기존 update.html의 이름을 adminupdate.html로 변경해줌